### PR TITLE
Update README to match Go README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import { createClient } from "@1password/sdk";
 
 // Creates an authenticated client.
 const client = await createClient({
-    auth: "<your_service_account_token>",
+    auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
     integrationName: "<your_integration_name>",
     integrationVersion: "<your_integration_version>",
 });

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -2,7 +2,7 @@ import { createClient } from "../src/client";
 
 // Creates an authenticated client.
 const client = await createClient({
-  auth: "<your_service_account_token>",
+  auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
   integrationName: "<your_integration_name>",
   integrationVersion: "<your_integration_version>",
 });


### PR DESCRIPTION
This MR updates the JS SDK README to match the formatting in the Go README, and adds more context for getting started. It makes the following changes:

- Specifies the supported authentication method earlier on.
- Moves the get started intro sentence beneath the get started header
- Notes that the service account will need access to the vaults where the secrets the person wants to use with the project are stored, since this can be an easy requirement to miss.
- Adds a step to export the service account token, since this isn't mentioned in the guide to creating a service account.
- Notes that they should use secret references in their code, so that the user will know to replace that with a reference to their own secret and have a link to learn more about what secret references are.
- Updates the secret reference in the code example to use the same syntax as in the Go example, making it generic instead of a reference to Netflix.
- Makes a couple minor style edits.