### PR TITLE
Use a new secret in CI and update the secret reference

### DIFF
--- a/client/test/client.test.js
+++ b/client/test/client.test.js
@@ -16,7 +16,6 @@ test("the right configuration is created", () => {
   expect(config.requestLibraryVersion).toBe("Fetch API");
   expect(config.programmingLanguage).toBe("JS");
   expect(config.sdkVersion).toBe("0010001");
-  // os is Linux because this test is mostly run in the pipeline
   expect(config.os).toBe(type());
   expect(config.osVersion).toBe("0.0.0");
   expect(config.architecture).toContain("64");

--- a/client/test/integration.test.js
+++ b/client/test/integration.test.js
@@ -4,7 +4,7 @@ const { retrieveSecret } = require('./task.js');
 
 test("test simple retrieving of secret", async () => {
     let p = retrieveSecret().then(secret => {
-        expect(secret).toBe("password")
+        expect(secret).toBe("test_password_42")
     })
     await p
 });
@@ -13,7 +13,7 @@ test("test retrieving of secret by 5 async clients", async () => {
     let promises = []
     for (let i = 0; i < 5; i++) {
         promises.push(retrieveSecret().then(secret => {
-            expect(secret).toBe("password")
+            expect(secret).toBe("test_password_42")
         }))
     }
     await Promise.all(promises)
@@ -28,7 +28,7 @@ test("test retrieving of secrets in parallel", async () => {
         worker.on("error", err => reject(err));
         worker.on("exit", _ => reject());
     });
-    promises.push(p1.then(res => expect(res).toBe("password")))
+    promises.push(p1.then(res => expect(res).toBe("test_password_42")))
 
     const p2 = new Promise((resolve, reject) => {
         const worker = new Worker(path.join(__dirname, 'task.js'), { workerData: process.env.OP_SERVICE_ACCOUNT_TOKEN });
@@ -36,7 +36,7 @@ test("test retrieving of secrets in parallel", async () => {
         worker.on("error", err => reject(err));
         worker.on("exit", _ => reject());
     });
-    promises.push(p2.then(res => expect(res).toBe("password")))
+    promises.push(p2.then(res => expect(res).toBe("test_password_42")))
 
     await Promise.all(promises)
 })

--- a/client/test/task.js
+++ b/client/test/task.js
@@ -14,7 +14,7 @@ async function retrieveSecret() {
         integrationVersion: DEFAULT_INTEGRATION_VERSION,
     })
 
-    return await client.secrets.resolve("op://testingVault/Real Login/password")
+    return await client.secrets.resolve("op://gowwbvgow7kxocrfmfvtwni6vi/6ydrn7ne6mwnqc2prsbqx4i4aq/password")
 }
 
 module.exports = { retrieveSecret }


### PR DESCRIPTION
According to our internal guidelines for using SA tokens in CI, I changed the Github secret to SA token from our shared b5test account. For tests to still pass I needed to update the secret references.