### PR TITLE
Standardize example documentation across repos

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,12 +4,11 @@ This folder contains code snippets that demonstrate how to use the 1Password JS 
 
 ## Prerequisites
 
-1. Clone the repository.
+1. Clone the repository and follow the steps to [get started](https://github.com/1Password/onepassword-sdk-js/blob/main/README.md).
 2. Make sure to export a valid service account token. For example:
 	```bash
 	export OP_SERVICE_ACCOUNT_TOKEN="<your token>"
 	```
-	Learn more about [service accounts](https://developer.1password.com/docs/service-accounts/get-started).
 3. Run the code in your preferred module format:
 	```bash
 	npm run esm-example

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,8 @@
 # Examples
 
-This folder contains code snippets that demonstrate how to import and use the 1Password JS SDK, using either ES modules or CommonJS modules. 
+This folder contains code snippets that demonstrate how to use the 1Password JS SDK to retrieve a secret from 1Password, using either ES modules or CommonJS modules. 
 
-## How to run
+## Prerequisites
 
 1. Clone the repository.
 2. Make sure to export a valid service account token. For example:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,17 +1,19 @@
 # Examples
 
-This folder contains code snippets showing how to import and use the
-1Password JS SDK, using either ES Modules or CommonJS modules.
+This folder contains code snippets that demonstrate how to import and use the 1Password JS SDK, using either ES modules or CommonJS modules. 
 
-### How to run
-1. Clone this repo
-2. Run the code in your preferred module format. First make sure to use a valid Service Account token:
-```bash
-export OP_SERVICE_ACCOUNT_TOKEN="<your token>"
-```
-```bash
-npm run esm-example
-```
-```bash
-npm run commonjs-example
-```
+## How to run
+
+1. Clone the repository.
+2. Make sure to export a valid service account token. For example:
+	```bash
+	export OP_SERVICE_ACCOUNT_TOKEN="<your token>"
+	```
+	Learn more about [service accounts](https://developer.1password.com/docs/service-accounts/get-started).
+3. Run the code in your preferred module format:
+	```bash
+	npm run esm-example
+	```
+	```bash
+	npm run commonjs-example
+	```

--- a/examples/index.cjs
+++ b/examples/index.cjs
@@ -1,14 +1,16 @@
 const sdk = require("@1password/sdk")
 
+// Gets your service account token from the OP_SERVICE_ACCOUNT_TOKEN environment variable.
+// Authenticates with your token and connects to 1Password.
 async function fetchSecret() {
-  // Creates an authenticated client.
   const client = await sdk.createClient({
     auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
     integrationName: "My 1Password Integration",
     integrationVersion: "v1.0.0",
   });
 
-  // Fetches a secret.
+// Retrieves a secret from 1Password. 
+// Takes a secret reference as input and returns the secret to which it points.
   return await client.secrets.resolve("op://vault/item/field");
 }
 

--- a/examples/index.mjs
+++ b/examples/index.mjs
@@ -1,12 +1,14 @@
 import { createClient } from "@1password/sdk";
 
-// Creates an authenticated client.
+// Gets your service account token from the OP_SERVICE_ACCOUNT_TOKEN environment variable.
+// Authenticates with your token and connects to 1Password.
 const client = await createClient({
   auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
   integrationName: "My 1Password Integration",
   integrationVersion: "v1.0.0",
 });
 
-// Fetches a secret.
+// Retrieves a secret from 1Password. 
+// Takes a secret reference as input and returns the secret to which it points.
 const secret = await client.secrets.resolve("op://vault/item/field");
 console.log(secret)


### PR DESCRIPTION
This PR standardizes the example folders across our repos. It includes the following changes:
- Edits to the README, including adding a description of the example to the intro, changing the header to "prerequisites," and adding an instruction to follow the steps to get started before running the example. 
- Edits to the example code comments to include a bit more information and use the same wording as I've proposed in the other repos.

Closes #25 

Question:
1. Is it necessary to go through the "get started" steps before running this? For example, would this work correctly without making any changes to the `.npmrc` file or setting the NPM token? 