### PR TITLE
Fix esm example

### DIFF
--- a/examples/index.mjs
+++ b/examples/index.mjs
@@ -1,7 +1,7 @@
-import { createClient } from "@1password/sdk";
+import sdk from "@1password/sdk";
 
 // Creates an authenticated client.
-const client = await createClient({
+const client = await sdk.createClient({
   auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
   integrationName: "My 1Password Integration",
   integrationVersion: "v1.0.0",


### PR DESCRIPTION
This PR fixes a bug in the esm example. Currently only the `createClient` is imported from the `@1password/sdk` module, this PR makes sure that we import the entire module instead and reference all the types and functions needed from it correctly.