### PR TITLE
Update README for beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@
 </p>
 
 <p align="center">
-  <a href="https://developer.1password.com/docs/sdks/">Documentation</a> | <a href="https://github.com/1Password/onepassword-sdk-js/tree/main/examples">Examples</a>
+   <a href="https://github.com/1Password/onepassword-sdk-js/tree/main/examples">Examples</a>
 <br/>
 
 ---
+
 The 1Password JavaScript SDK offers programmatic access to your secrets in 1Password with JavaScript. The SDK currently supports `Node.js`. During the beta, you can create, retrieve, update, and delete items and resolve secret references.
 
 ## 🔑 Authentication
@@ -27,42 +28,42 @@ Before you get started, [create a service account](https://developer.1password.c
 
 1Password SDKs don't yet support using secret references with query parameters, so you can't retrieve file attachments or SSH keys, or get more information about field metadata.
 
-When managing items with 1Password SDKs, you must use [unique identifiers (IDs)](https://developer.1password.com/docs/sdks/concepts#unique-identifiers-ids) in place of vault, item, and field names.
+When managing items with 1Password SDKs, you must use unique identifiers (IDs) in place of vault, item, and field names.
 
 ## 🚀 Get started
 
 To use the 1Password JavaScript SDK in your project:
 
 1. Provision your [service account](#authentication) token. We recommend provisioning your token from the environment. For example, to export your token to the `OP_SERVICE_ACCOUNT_TOKEN` environment variable:
-    
-    **macOS or Linux**
-    
-    ```bash
-    export OP_SERVICE_ACCOUNT_TOKEN=<your-service-account-token>
-    ```
-    
-    **Windows**
-    
-    ```powershell
-    $Env:OP_SERVICE_ACCOUNT_TOKEN = "<your-service-account-token>"
-    ```
+
+   **macOS or Linux**
+
+   ```bash
+   export OP_SERVICE_ACCOUNT_TOKEN=<your-service-account-token>
+   ```
+
+   **Windows**
+
+   ```powershell
+   $Env:OP_SERVICE_ACCOUNT_TOKEN = "<your-service-account-token>"
+   ```
 
 2. Install the 1Password JavaScript SDK in your project:
 
-    ```bash
-    ## NPM
-    npm install @1password/sdk@beta
-    ```
+   ```bash
+   ## NPM
+   npm install @1password/sdk@beta
+   ```
 
-    ```bash
-    ## PNPM
-    pnpm add @1password/sdk@beta
-    ```
+   ```bash
+   ## PNPM
+   pnpm add @1password/sdk@beta
+   ```
 
-    ```bash
-    ## Yarn
-    yarn add @1password/sdk@beta
-    ```
+   ```bash
+   ## Yarn
+   yarn add @1password/sdk@beta
+   ```
 
 3. Use the JavaScript SDK in your project:
 
@@ -83,9 +84,3 @@ const secret = await client.secrets.resolve("op://vault/item/field");
 Make sure to use [secret reference URIs](https://developer.1password.com/docs/cli/secrets-reference-syntax/) with the syntax `op://vault/item/field` to securely load secrets from 1Password into your code.
 
 Inside `createClient()`, set `integrationName` to the name of your application and `integrationVersion` to the version of your application.
-
-## 📖 Learn more
-
-- [Load secrets with 1Password SDKs](https://developer.1password.com/docs/sdks/load-secrets)
-- [Manage items with 1Password SDKs](https://developer.1password.com/docs/sdks/manage-items)
-- [1Password SDK concepts](https://developer.1password.com/docs/sdks/concepts)


### PR DESCRIPTION
This MR updates the README for the beta. It includes the following changes:

- Some improved styling, like a centered header and beta callout
- Links to documentation
- Edits to reflect edits made for beta docs, like changing "read access" to "access", updating the warning callout text, etc.
- Separates authentication & limitation info into their own sections
- Updates get started steps to reflect beta docs changes (for example, removed any steps that are no longer needed for the beta)
- Rephrases token provision section to reflect beta docs changes, explaining using the `OP_SERVICE_ACCOUNT_TOKEN` environment variable as an option
- Adds PowerShell examples

Question for reviewer: Does the "Use the SDK in your project" code example need to be updated?