### PR TITLE
Always pass Windows OS name that is accepted by the server

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,24 +32,3 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: npm test
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm install
-
-      - name: Style
-        run: npm run prettier
-      
-      - name: Lint
-        run: npm run eslint

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,30 @@ on:
 jobs:
 
   test:
-    name: Lint & Test
+    name: Test
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm install
+
+      - name: Test
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: npm test
+
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -30,29 +53,3 @@ jobs:
       
       - name: Lint
         run: npm run eslint
-
-      - name: Test
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: npm test
-  
-  test-windows:
-    name: Test on Windows
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm install
-
-      - name: Test
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: npm test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
 
@@ -31,4 +32,25 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: npm test
+  
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm install
+
+      - name: Style
+        run: npm run prettier
+      
+      - name: Lint
+        run: npm run eslint

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,9 +4,6 @@ on:
   push:
     paths-ignore:
       - '**.md'
-  pull_request:
-    paths-ignore:
-      - '**.md'
 jobs:
 
   test:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,4 +35,24 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: npm test
+  
+  test-windows:
+    name: Test on Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm install
+
+      - name: Test
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: npm test

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -33,8 +33,16 @@ export const clientAuthConfig = (
     requestLibraryName: "Fetch API",
     requestLibraryVersion: "Fetch API",
     // Only supported on Node.js
-    os: os.type().toLowerCase(),
+    os: getOsName(),
     osVersion: defaultOsVersion,
     architecture: os.arch(),
   };
 };
+
+function getOsName() : string {
+  const os_name = os.type().toLowerCase() 
+  if(os_name == "windows_nt") {
+    return "Windows"
+  }
+  return os_name
+}

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -41,7 +41,7 @@ export const clientAuthConfig = (
 
 export const getOsName = (): string => {
   const os_name = os.type();
-  if (os_name === "windows_nt") {
+  if (os_name === "Windows_NT") {
     return "Windows";
   }
   return os_name;

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -32,7 +32,6 @@ export const clientAuthConfig = (
     integrationVersion: userConfig.integrationVersion,
     requestLibraryName: "Fetch API",
     requestLibraryVersion: "Fetch API",
-    // Only supported on Node.js
     os: getOsName(),
     osVersion: defaultOsVersion,
     architecture: os.arch(),
@@ -40,9 +39,10 @@ export const clientAuthConfig = (
 };
 
 export const getOsName = (): string => {
-  const os_name = os.type();
-  if (os_name === "Windows_NT") {
-    return "Windows";
+  // Only supported on Node.js
+  const os_name = os.type().toLowerCase();
+  if (os_name === "windows_nt") {
+    return "windows";
   }
   return os_name;
 };

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -40,7 +40,7 @@ export const clientAuthConfig = (
 };
 
 export const getOsName = (): string => {
-  const os_name = os.type().toLowerCase();
+  const os_name = os.type();
   if (os_name === "windows_nt") {
     return "Windows";
   }

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -39,10 +39,10 @@ export const clientAuthConfig = (
   };
 };
 
-function getOsName(): string {
+const getOsName = (): string => {
   const os_name = os.type().toLowerCase();
-  if (os_name == "windows_nt") {
+  if (os_name === "windows_nt") {
     return "Windows";
   }
   return os_name;
-}
+};

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -39,10 +39,10 @@ export const clientAuthConfig = (
   };
 };
 
-function getOsName() : string {
-  const os_name = os.type().toLowerCase() 
-  if(os_name == "windows_nt") {
-    return "Windows"
+function getOsName(): string {
+  const os_name = os.type().toLowerCase();
+  if (os_name == "windows_nt") {
+    return "Windows";
   }
-  return os_name
+  return os_name;
 }

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -39,7 +39,7 @@ export const clientAuthConfig = (
   };
 };
 
-const getOsName = (): string => {
+export const getOsName = (): string => {
   const os_name = os.type().toLowerCase();
   if (os_name === "windows_nt") {
     return "Windows";

--- a/client/test/client.test.js
+++ b/client/test/client.test.js
@@ -1,7 +1,6 @@
 const { createClientWithCore } = require("../dist/client_builder.js");
-const { clientAuthConfig } = require("../dist/configuration.js");
+const { clientAuthConfig, getOsName } = require("../dist/configuration.js");
 const { TestCore } = require("./test_core");
-const { type } = require("os");
 
 test("the right configuration is created", () => {
   const config = clientAuthConfig({
@@ -17,7 +16,7 @@ test("the right configuration is created", () => {
   expect(config.requestLibraryVersion).toBe("Fetch API");
   expect(config.programmingLanguage).toBe("JS");
   expect(config.sdkVersion).toBe("0010001");
-  expect(config.os).toBe(type().toLowerCase());
+  expect(config.os).toBe(getOsName());
   expect(config.osVersion).toBe("0.0.0");
   expect(config.architecture).toContain("64");
 });


### PR DESCRIPTION
## Summary

On Windows 10 devices the `os.type` function was returning `windows_nt` and this value is not accepted by the 1Password server. We need to modify this to `windows`.