### PR TITLE
Update README to simplify service account instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@
 
 The 1Password JavaScript SDK offers programmatic access to your secrets in 1Password with JavaScript. The SDK currently supports `Node.js`. During the beta, you can create, retrieve, update, and delete items and resolve secret references.
 
-## 🔑 Authentication
-
 1Password SDKs support authentication with [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/). 
-
-Before you get started, [create a service account](https://developer.1password.com/docs/service-accounts/get-started/#create-a-service-account) and give it the appropriate permissions in the vaults where the items you want to use with the SDK are saved.
 
 ## ❗ Limitations
 
@@ -34,7 +30,8 @@ When managing items with 1Password SDKs, you must use [unique identifiers (IDs)]
 
 To use the 1Password JavaScript SDK in your project:
 
-1. Provision your [service account](#authentication) token. We recommend provisioning your token from the environment. For example, to export your token to the `OP_SERVICE_ACCOUNT_TOKEN` environment variable:
+1. [Create a service account](https://my.1password.com/developer-tools/infrastructure-secrets/serviceaccount/) and give it the appropriate permissions in the vaults where the items you want to use with the SDK are saved.
+2. Provision your service account token. We recommend provisioning your token from the environment. For example, to export your token to the `OP_SERVICE_ACCOUNT_TOKEN` environment variable:
 
    **macOS or Linux**
 
@@ -48,7 +45,7 @@ To use the 1Password JavaScript SDK in your project:
    $Env:OP_SERVICE_ACCOUNT_TOKEN = "<your-service-account-token>"
    ```
 
-2. Install the 1Password JavaScript SDK in your project:
+3. Install the 1Password JavaScript SDK in your project:
 
    ```bash
    ## NPM
@@ -65,7 +62,7 @@ To use the 1Password JavaScript SDK in your project:
    yarn add @1password/sdk@beta
    ```
 
-3. Use the JavaScript SDK in your project:
+4. Use the JavaScript SDK in your project:
 
 ```js
 import { createClient } from "@1password/sdk";


### PR DESCRIPTION
This MR updates the README to directly link to the 1password.com page where you can create a service account. It also simplifies the service account information by moving this instruction into the get started section and removing the authentication section.

Relates to this issue: https://gitlab.1password.io/dev/sdk/sdk-core/-/issues/141#note_3220318