### PR TITLE
Document supported functionality in the README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Supported functionality
 
-1Password SDKs are in active development. We're keen to hear what you'd like to see next. Let us know by [upvoting](https://github.com/1Password/onepassword-sdk-go/issues) or [filing](https://github.com/1Password/onepassword-sdk-go/issues/new/choose) an issue.
+1Password SDKs are in active development. We're keen to hear what you'd like to see next. Let us know by [upvoting](https://github.com/1Password/onepassword-sdk-js/issues) or [filing](https://github.com/1Password/onepassword-sdk-js/issues/new/choose) an issue.
 
 ### Item management
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,62 @@
 
 ---
 
-The 1Password JavaScript SDK offers programmatic access to your secrets in 1Password with JavaScript. The SDK currently supports `Node.js`. During the beta, you can create, retrieve, update, and delete items and resolve secret references.
+## Supported functionality
 
-1Password SDKs support authentication with [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/). 
+1Password SDKs are in active development. We're keen to hear what you'd like to see next. Let us know by [upvoting](https://github.com/1Password/onepassword-sdk-go/issues) or [filing](https://github.com/1Password/onepassword-sdk-go/issues/new/choose) an issue.
 
-## ❗ Limitations
+### Item management
 
-1Password SDKs don't yet support using secret references with query parameters, so you can't retrieve file attachments or SSH keys, or get more information about field metadata.
+Operations:
 
-1Password SDKs currently only support operations on text and concealed fields. As a result, you can't edit items that include information saved in other types of fields.
+- [x] [Retrieve secrets](https://developer.1password.com/docs/sdks/load-secrets)
+- [x] [Retrieve items](https://developer.1password.com/docs/sdks/manage-items#get-an-item)
+- [x] [Create items](https://developer.1password.com/docs/sdks/manage-items#create-an-item)
+- [x] [Update items](https://developer.1password.com/docs/sdks/manage-items#edit-an-item)
+- [x] [Delete items](https://developer.1password.com/docs/sdks/manage-items#delete-an-item)
+- [ ] List items
+- [ ] Add & update tags on items 
 
-When managing items with 1Password SDKs, you must use [unique identifiers (IDs)](https://developer.1password.com/docs/sdks/concepts#unique-identifiers) in place of vault, item, and field names.
+Field types:
+- [x] API Keys
+- [x] Passwords
+- [x] Concealed fields
+- [x] Text fields
+- [x] Notes
+- [x] SSH private keys (partially supported: supported in resolving secret references, not yet supported in item create/get/update)
+- [ ] SSH public keys, fingerprint and key type
+- [ ] One-time passwords \
+- [ ] Files attachments and Document items
+- [x] URLs
+- [x] Credit card number & type
+- [x] Phone numbers
+
+### Vault management
+- [ ] Retrieve vaults
+- [ ] Create vaults ([#50](https://github.com/1Password/onepassword-sdk-js/issues/50))
+- [ ] Update vaults
+- [ ] Delete vaults
+- [ ] List vaults
+
+### User & access management
+- [ ] Provision users
+- [ ] Retrieve users
+- [ ] List users
+- [ ] Suspend users
+- [ ] Create groups
+- [ ] Update group membership
+- [ ] Update vault access & permissions
+
+### Compliance & reporting
+- [ ] Watchtower insights
+- [ ] Travel mode
+- [ ] Events. For now, use [1Password Events Reporting API](https://developer.1password.com/docs/events-api/) directly.
+
+### Authentication
+
+- [x] [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/)
+- [ ] User authentication
+- [ ] 1Password Connect. For now, use [1Password/connect-sdk-go](https://github.com/1Password/connect-sdk-go).
 
 ## 🚀 Get started
 


### PR DESCRIPTION
This PR duplicates the work done in Go here: https://github.com/1Password/onepassword-sdk-go/pull/118 with linked issues updated for JS.