### PR TITLE
Direct Users to the Correct Connect SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Field types:
 
 - [x] [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/)
 - [ ] User authentication
-- [ ] 1Password Connect. For now, use [1Password/connect-sdk-go](https://github.com/1Password/connect-sdk-go).
+- [ ] 1Password Connect. For now, use [1Password/connect-sdk-js](https://github.com/1Password/connect-sdk-js).
 
 ## 📖 Learn more
 


### PR DESCRIPTION
The README was telling users to use the connect Go SDK on the JS SDK Repo. Updated the readme to direct users towards the Connect JS SDK.