### PR TITLE
Change the way we call ClientInvoke due to new changes in SDK Core #138

### DIFF
--- a/client/src/core.ts
+++ b/client/src/core.ts
@@ -41,7 +41,6 @@ export interface InvokeConfig {
   /**
    *  Identifies the client instance for which you called the function.
    */
-  clientId: number;
   invocation: Invocation;
 }
 
@@ -49,6 +48,15 @@ export interface InvokeConfig {
  *  Calls certain logic from the SDK core, with the given parameters.
  */
 interface Invocation {
+  /**
+   *  Identifies the client instance for which you called the function.
+   */
+  clientId?: number;
+
+  parameter: Parameters;
+}
+
+export interface Parameters {
   /**
    *  Functionality name
    */

--- a/client/src/items.ts
+++ b/client/src/items.ts
@@ -44,11 +44,13 @@ export class ItemsSource implements ItemsApi {
    */
   public async create(params: types.ItemCreateParams): Promise<types.Item> {
     const invocationConfig: InvokeConfig = {
-      clientId: this.#inner.id,
       invocation: {
-        name: "ItemsCreate",
-        parameters: {
-          params,
+        clientId: this.#inner.id,
+        parameter: {
+          name: "ItemsCreate",
+          parameters: {
+            params,
+          },
         },
       },
     };
@@ -62,12 +64,14 @@ export class ItemsSource implements ItemsApi {
    */
   public async get(vaultId: string, itemId: string): Promise<types.Item> {
     const invocationConfig: InvokeConfig = {
-      clientId: this.#inner.id,
       invocation: {
-        name: "ItemsGet",
-        parameters: {
-          vault_id: vaultId,
-          item_id: itemId,
+        clientId: this.#inner.id,
+        parameter: {
+          name: "ItemsGet",
+          parameters: {
+            vault_id: vaultId,
+            item_id: itemId,
+          },
         },
       },
     };
@@ -81,11 +85,13 @@ export class ItemsSource implements ItemsApi {
    */
   public async put(item: types.Item): Promise<types.Item> {
     const invocationConfig: InvokeConfig = {
-      clientId: this.#inner.id,
       invocation: {
-        name: "ItemsPut",
-        parameters: {
-          item,
+        clientId: this.#inner.id,
+        parameter: {
+          name: "ItemsPut",
+          parameters: {
+            item,
+          },
         },
       },
     };
@@ -99,12 +105,14 @@ export class ItemsSource implements ItemsApi {
    */
   public async delete(vaultId: string, itemId: string): Promise<void> {
     const invocationConfig: InvokeConfig = {
-      clientId: this.#inner.id,
       invocation: {
-        name: "ItemsDelete",
-        parameters: {
-          vault_id: vaultId,
-          item_id: itemId,
+        clientId: this.#inner.id,
+        parameter: {
+          name: "ItemsDelete",
+          parameters: {
+            vault_id: vaultId,
+            item_id: itemId,
+          },
         },
       },
     };
@@ -118,11 +126,13 @@ export class ItemsSource implements ItemsApi {
     vaultId: string,
   ): Promise<SdkIterable<types.ItemOverview>> {
     const invocationConfig: InvokeConfig = {
-      clientId: this.#inner.id,
       invocation: {
-        name: "ItemsListAll",
-        parameters: {
-          vault_id: vaultId,
+        clientId: this.#inner.id,
+        parameter: {
+          name: "ItemsListAll",
+          parameters: {
+            vault_id: vaultId,
+          },
         },
       },
     };

--- a/client/src/secrets.ts
+++ b/client/src/secrets.ts
@@ -25,11 +25,13 @@ export class SecretsSource implements SecretsApi {
    */
   public async resolve(secretReference: string): Promise<string> {
     const invocationConfig: InvokeConfig = {
-      clientId: this.#inner.id,
       invocation: {
-        name: "SecretsResolve",
-        parameters: {
-          secret_reference: secretReference,
+        clientId: this.#inner.id,
+        parameter: {
+          name: "SecretsResolve",
+          parameters: {
+            secret_reference: secretReference,
+          },
         },
       },
     };

--- a/client/src/vaults.ts
+++ b/client/src/vaults.ts
@@ -1,4 +1,4 @@
-import { InvokeConfig, InnerClient } from "./core.js";
+import { InvokeConfig, InnerClient, Parameters } from "./core.js";
 import * as types from "./types.js";
 import { SdkIterable } from "./iterator.js";
 
@@ -24,10 +24,12 @@ export class VaultsSource implements VaultsApi {
    */
   public async listAll(): Promise<SdkIterable<types.VaultOverview>> {
     const invocationConfig: InvokeConfig = {
-      clientId: this.#inner.id,
       invocation: {
-        name: "VaultsListAll",
-        parameters: {},
+        clientId: this.#inner.id,
+        parameter: {
+          name: "VaultsListAll",
+          parameters: {},
+        },
       },
     };
     return new SdkIterable<types.VaultOverview>(


### PR DESCRIPTION
Due to the upcoming changes in the SDK core, this PR will update the JS SDK to correctly call the clientInvoke method.