### PR TITLE
Update JS Release Process

### DIFF
--- a/client/release/scripts/release.sh
+++ b/client/release/scripts/release.sh
@@ -25,19 +25,17 @@ cleanup() {
 # waits for NPM to publish on internal registry to update package json
 wait_for_npm_publish(){
     package_name="${1}"
+    updated_npm_version="${2}"
 
-    # Assign the correct version based off if its core or not
-    updated_npm_version=$( [[ "$package_name" == *"core"* ]] && echo "$version_sdk_core" || echo "$version_sdk" )
-    
     while true; do
-    npm_verison=$(npm view "$package_name" version)
+    npm_version=$(npm view "$package_name" version)
     # if package matches npm registry than break out of loop and update package.json
-    if [ "$npm_verison" == "$updated_npm_version" ]; then
-        echo "The package version $npm_verison is up to date!"
+    if [ "$npm_version" == "$updated_npm_version" ]; then
+        echo "The package version $npm_version is up to date!"
         break
     else
         # Sleep for another 5 seconds if it still didnt sync
-        echo "The package version $npm_verison is not up to date. Latest version is $updated_npm_version."
+        echo "The $updated_npm_version package version is not yet published to NPM. Waiting..."
         sleep 5
     fi
 done
@@ -89,7 +87,7 @@ fi
   cd client
   if [ "$core_modified" = true ]; then
     # Wait for npm to be update to the latest version
-    wait_for_npm_publish @1password/sdk-core
+    wait_for_npm_publish @1password/sdk-core "${version_sdk_core}"
     # Update @1password/sdk-core dependancy to the latest
     npm install @1password/sdk-core@latest -E
   fi
@@ -110,7 +108,7 @@ fi
             npm dist-tag add @1password/sdk@${version_sdk} latest
 
             # Sleep for about 12s to allow npm registry to publish the latest version
-            wait_for_npm_publish @1password/sdk
+            wait_for_npm_publish @1password/sdk "${version_sdk}"
             # Update dependency in examples to run off the latest SDK
             cd ../examples && npm install @1password/sdk@latest -E
 

--- a/client/release/scripts/release.sh
+++ b/client/release/scripts/release.sh
@@ -67,9 +67,11 @@ fi
 
   cd client
   if [ "$core_modified" = true ]; then
+    # Sleep for about 12s to allow npm registry to publish the latest version
+    sleep 12
     # Update @1password/sdk-core dependancy to the latest
-    # WARNING: THIS COMMAND DOESNT WORK... FIX THIS OR UNTILL ITS FIXED UPDATE IT MANUALLY BEFORE PUBLISHING 1pasword-sdk at the dry run stage
-    npm install @1password/sdk-core@latest --save-exact
+    npm install @1password/sdk-core@"${version_sdk_core}" -E
+
   fi
 
   # Update sdk version number to the latest
@@ -87,9 +89,10 @@ fi
             RELEASE_CHANNEL="${RELEASE_CHANNEL}" npm run publish-prod 
             npm dist-tag add @1password/sdk@${version_sdk} latest
 
+            # Sleep for about 12s to allow npm registry to publish the latest version
+            sleep 12
             # Update dependency in examples to run off the latest SDK
-            # WARNING: THIS COMMAND DOESNT WORK... FIX THIS BEFORE MERGING RC BRANCH TO MAIN
-            cd ../examples && npm install @1password/sdk@latest --save-exact
+            cd ../examples && npm install @1password/sdk@"${version_sdk}" -E
 
             # Check if the latest SDK client is pulled correctly
             cd ../ && npm install

--- a/client/release/scripts/release.sh
+++ b/client/release/scripts/release.sh
@@ -22,6 +22,27 @@ cleanup() {
     exit 1   
 }
 
+# waits for NPM to publish on internal registry to update package json
+wait_for_npm_publish(){
+    package_name="${1}"
+
+    # Assign the correct version based off if its core or not
+    updated_npm_version=$( [[ "$package_name" == *"core"* ]] && echo "$version_sdk_core" || echo "$version_sdk" )
+    
+    while true; do
+    npm_verison=$(npm view "$package_name" version)
+    # if package matches npm registry than break out of loop and update package.json
+    if [ "$npm_verison" == "$updated_npm_version" ]; then
+        echo "The package version $npm_verison is up to date!"
+        break
+    else
+        # Sleep for another 5 seconds if it still didnt sync
+        echo "The package version $npm_verison is not up to date. Latest version is $updated_npm_version."
+        sleep 5
+    fi
+done
+}
+
 # Set the trap to call the cleanup function on exit
 trap cleanup SIGINT ERR
 
@@ -67,11 +88,10 @@ fi
 
   cd client
   if [ "$core_modified" = true ]; then
-    # Sleep for about 12s to allow npm registry to publish the latest version
-    sleep 12
+    # Wait for npm to be update to the latest version
+    wait_for_npm_publish @1password/sdk-core
     # Update @1password/sdk-core dependancy to the latest
-    npm install @1password/sdk-core -E
-
+    npm install @1password/sdk-core@latest -E
   fi
 
   # Update sdk version number to the latest
@@ -90,9 +110,9 @@ fi
             npm dist-tag add @1password/sdk@${version_sdk} latest
 
             # Sleep for about 12s to allow npm registry to publish the latest version
-            sleep 12
+            wait_for_npm_publish @1password/sdk
             # Update dependency in examples to run off the latest SDK
-            cd ../examples && npm install @1password/sdk -E
+            cd ../examples && npm install @1password/sdk@latest -E
 
             # Check if the latest SDK client is pulled correctly
             cd ../ && npm install

--- a/client/release/scripts/release.sh
+++ b/client/release/scripts/release.sh
@@ -70,7 +70,7 @@ fi
     # Sleep for about 12s to allow npm registry to publish the latest version
     sleep 12
     # Update @1password/sdk-core dependancy to the latest
-    npm install @1password/sdk-core@"${version_sdk_core}" -E
+    npm install @1password/sdk-core -E
 
   fi
 
@@ -92,7 +92,7 @@ fi
             # Sleep for about 12s to allow npm registry to publish the latest version
             sleep 12
             # Update dependency in examples to run off the latest SDK
-            cd ../examples && npm install @1password/sdk@"${version_sdk}" -E
+            cd ../examples && npm install @1password/sdk -E
 
             # Check if the latest SDK client is pulled correctly
             cd ../ && npm install

--- a/client/release/scripts/release.sh
+++ b/client/release/scripts/release.sh
@@ -106,8 +106,8 @@ fi
         y)
             RELEASE_CHANNEL="${RELEASE_CHANNEL}" npm run publish-prod 
             npm dist-tag add @1password/sdk@${version_sdk} latest
-
-            # Sleep for about 12s to allow npm registry to publish the latest version
+            
+            # Wait for npm to be update to the latest version
             wait_for_npm_publish @1password/sdk "${version_sdk}"
             # Update dependency in examples to run off the latest SDK
             cd ../examples && npm install @1password/sdk@latest -E


### PR DESCRIPTION
This PR will update the `release.sh` script to properly update the package.json to the latest version when running the `release.sh` script.


Tested this out on a private repo where I tested different seconds to sleep at 12s was the sweet spot where it was consistently publishing the newest versions and its not too long.

Also removed latest as thats the default and changed from --save-exact to -E for shortform.