### PR TITLE
convert examples to tests with env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "test": "npm test --workspaces --if-present",
     "esm-example": "npm run build --workspace client && npm run esm-example --workspace examples",
+    "test:esm-example": "npm run build --workspace client && npm run test:esm-example --workspace tests",
     "commonjs-example": "npm run build --workspace client && npm run commonjs-example --workspace examples",
+    "test:commonjs-example": "npm run build --workspace client && npm run test:commonjs-example --workspace tests",
     "prepare": "npm run build --workspace client",
     "prettier": "npm run prettier --workspaces --if-present",
     "prettier-fix": "npm run prettier-fix --workspaces --if-present",
@@ -20,6 +22,7 @@
   "workspaces": [
     "client",
     "examples",
-    "wasm"
+    "wasm",
+	"tests"
   ]
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,6 @@
+To test, make sure the following env vars are defined:
+
+```sh
+export CORE_SDK_TEST_SECRET_REF='op://vault/item/field'
+export CORE_SDK_TEST_VAULT_ID='' # can get from `op list vaults`
+```

--- a/tests/index.cjs
+++ b/tests/index.cjs
@@ -1,0 +1,122 @@
+// [developer-docs.sdk.js/common-js.sdk-import]-start
+const sdk = require("@1password/sdk");
+// [developer-docs.sdk.js/common-js.sdk-import]-end
+
+const vaultId = process.env.CORE_SDK_TEST_VAULT_ID;
+const secretRef = process.env.CORE_SDK_TEST_SECRET_REF;
+
+
+async function fetchSecret() {
+	// Creates an authenticated client.
+	const client = await sdk.createClient({
+		auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
+		// Set the following to your own integration name and version.
+		integrationName: "My 1Password Integration",
+		integrationVersion: "v1.0.0",
+	});
+
+	return await client.secrets.resolve(secretRef);
+}
+
+async function manageItems() {
+	// Creates an authenticated client.
+	const client = await sdk.createClient({
+		auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
+		integrationName: "My 1Password Integration",
+		integrationVersion: "v1.0.0",
+	});
+
+	const vaults = await client.vaults.listAll();
+
+	for await (const vault of vaults) {
+		console.log(vault.id + " " + vault.title);
+		const items = await client.items.listAll(vault.id);
+		for await (const item of items) {
+			console.log(item.id + " " + item.title);
+		}
+	}
+
+	// Create an item
+	let item = await client.items.create({
+		title: "My Item",
+		category: sdk.ItemCategory.Login,
+		vaultId,
+		fields: [
+			{
+				id: "username",
+				title: "username",
+				fieldType: sdk.ItemFieldType.Text,
+				value: "my username",
+			},
+			{
+				id: "password",
+				title: "password",
+				fieldType: sdk.ItemFieldType.Concealed,
+				value: "my secret value",
+			},
+			{
+				id: "onetimepassword",
+				title: "one-time password",
+				sectionId: "custom section",
+				fieldType: sdk.ItemFieldType.Totp,
+				value:
+					"otpauth://totp/my-example-otp?secret=jncrjgbdjnrncbjsr&issuer=1Password",
+			},
+		],
+		sections: [
+			{
+				id: "custom section",
+				title: "my section",
+			},
+		],
+		tags: ["test tag 1", "test tag 2"],
+		websites: [
+			{
+				url: "example.com",
+				label: "url",
+				autofillBehavior: sdk.AutofillBehavior.AnywhereOnWebsite,
+			},
+		],
+	});
+
+	// Get a one-time password code.
+	let element = item.fields.find((element) => {
+		return element.fieldType == sdk.ItemFieldType.Totp;
+	});
+
+	if (!element) {
+		console.error("no totp field found on item");
+		return;
+	}
+
+	switch (element.details.type) {
+		case "Otp": {
+			if (element.details.content.code) {
+				console.log(element.details.content.code);
+			} else {
+				console.error(element.details.content.errorMessage);
+			}
+		}
+		default:
+	}
+
+	// Edit an item (change the password)
+	let newItem = {
+		...item,
+		fields: item.fields.map((f) => {
+			if (f.title == "password") {
+				return { ...f, value: "my-new-password" };
+			} else {
+				return f;
+			}
+		}),
+	};
+	let updatedItem = await client.items.put(newItem);
+	console.log(updatedItem.fields);
+
+	// Delete an item
+	await client.items.delete(item.vaultId, item.id);
+}
+
+manageItems();
+fetchSecret().then(console.log);

--- a/tests/index.mjs
+++ b/tests/index.mjs
@@ -1,0 +1,137 @@
+// [developer-docs.sdk.js/es-modules.sdk-import]-start
+import sdk from "@1password/sdk";
+// [developer-docs.sdk.js/es-modules.sdk-import]-end
+console.log("Hello, 1Password!");
+// [developer-docs.sdk.js.client-initialization]-start
+// Creates an authenticated client.
+const client = await sdk.createClient({
+	auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
+	// Set the following to your own integration name and version.
+	integrationName: "My 1Password Integration",
+	integrationVersion: "v1.0.0",
+});
+console.log("Client created");
+// [developer-docs.sdk.js.client-initialization]-end
+
+// [developer-docs.sdk.js.list-vaults]-start
+const vaults = await client.vaults.listAll();
+for await (const vault of vaults) {
+	console.log(vault.id + " " + vault.title);
+}
+// [developer-docs.sdk.js.list-vaults]-end
+
+// [developer-docs.sdk.js.list-items]-start
+const vaultId = process.env.CORE_SDK_TEST_VAULT_ID;
+const items = await client.items.listAll(vaultId);
+for await (const item of items) {
+	console.log(item.id + " " + item.title);
+}
+// [developer-docs.sdk.js.list-items]-end
+
+// [developer-docs.sdk.js.resolve-secret]-start
+// Fetches a secret.
+const secretRef = process.env.CORE_SDK_TEST_SECRET_REF;
+const secret = await client.secrets.resolve(secretRef);
+console.log(secret);
+// [developer-docs.sdk.js.resolve-secret]-end
+
+// [developer-docs.sdk.js.create-item]-start
+// Creates an item
+let item = await client.items.create({
+	title: "My Item",
+	category: sdk.ItemCategory.Login,
+	vaultId: vaultId,
+	fields: [
+		{
+			id: "username",
+			title: "username",
+			fieldType: sdk.ItemFieldType.Text,
+			value: "my username",
+		},
+		{
+			id: "password",
+			title: "password",
+			fieldType: sdk.ItemFieldType.Concealed,
+			value: "my secret value",
+		},
+		{
+			id: "onetimepassword",
+			title: "one-time password",
+			sectionId: "custom section",
+			fieldType: sdk.ItemFieldType.Totp,
+			value:
+				"otpauth://totp/my-example-otp?secret=jncrjgbdjnrncbjsr&issuer=1Password",
+		},
+	],
+	sections: [
+		{
+			id: "custom section",
+			title: "my section",
+		},
+	],
+	tags: ["test tag 1", "test tag 2"],
+	websites: [
+		{
+			url: "example.com",
+			label: "url",
+			autofillBehavior: sdk.AutofillBehavior.AnywhereOnWebsite,
+		},
+	],
+});
+// [developer-docs.sdk.js.create-item]-end
+
+// [developer-docs.sdk.js.resolve-totp-code]-start
+// Fetches a TOTP code.
+const code = await client.secrets.resolve(
+	`op://${item.vaultId}/${item.id}/TOTP_onetimepassword?attribute=totp`,
+);
+console.log(code);
+// [developer-docs.sdk.js.resolve-totp-code]-end
+
+// [developer-docs.sdk.js.get-totp-item-crud]-start
+// Get a one-time password code.
+let element = item.fields.find((element) => {
+	return element.fieldType == sdk.ItemFieldType.Totp;
+});
+
+if (!element) {
+	console.error("no totp field found on item");
+} else {
+	switch (element.details.type) {
+		case "Otp": {
+			if (element.details.content.code) {
+				console.log(element.details.content.code);
+			} else {
+				console.error(element.details.content.errorMessage);
+			}
+		}
+		default:
+	}
+}
+// [developer-docs.sdk.js.get-totp-item-crud]-end
+
+// [developer-docs.sdk.js.get-item]-start
+let retrievedItem = await client.items.get(item.vaultId, item.id);
+// [developer-docs.sdk.js.get-item]-end
+
+// [developer-docs.sdk.js.update-item]-start
+// Edit an item (change the password)
+let newItem = {
+	...retrievedItem,
+	fields: retrievedItem.fields.map((f) => {
+		if (f.title == "password") {
+			return { ...f, value: "my-new-password" };
+		} else {
+			return f;
+		}
+	}),
+};
+let updatedItem = await client.items.put(newItem);
+// [developer-docs.sdk.js.update-item]-end
+
+console.log(updatedItem.fields);
+
+// [developer-docs.sdk.js.delete-item]-start
+// Deletes an item
+await client.items.delete(item.vaultId, item.id);
+// [developer-docs.sdk.js.delete-item]-end

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "1password-sdk-examples-tests",
+	"description": "Examples converted to tests for the 1Password SDK",
+	"scripts": {
+		"test:esm-example": "node index.mjs",
+		"test:commonjs-example": "node index.cjs",
+		"prettier": "prettier --check index.*js",
+		"prettier-fix": "prettier --write index.*js"
+	},
+	"dependencies": {
+		"@1password/sdk": "0.1.2"
+	},
+	"devDependencies": {
+		"prettier": "3.1.1"
+	}
+}


### PR DESCRIPTION
This PR duplicate the existing examples folder that we frequently use as tests, and modify it so that they fetch the test secret reference and vault id from env vars, making testing wtih the examples much, much easier.