### PR TITLE
Use the correct 0.1.5 version in package.json

### DIFF
--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1password/sdk-core",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "author": "1Password",
   "license": "MIT",
   "description": "The 1Password Rust SDK core built with `wasm_bindgen`",


### PR DESCRIPTION
In the last release, the version 0.1.5 of the SDK core has been released on NPM:
* https://github.com/1Password/onepassword-sdk-js/pull/116
* https://www.npmjs.com/package/@1password/sdk-core

However, this wasn't updated in `package.json`. This breaks the local testing workflow, in that:
1. the `@1password/sdk` package requires `@1password/sdk-core` version 0.1.5.
2. the locally built `@1password/sdk-core` has version 0.1.3.
3. because of that, the official package from NPM with version 0.1.5 is pulled, which means that new changes cannot be tested unless the version in `package.json` is updated manually.

This should fix that.