### PR TITLE
Update JS release script to correctly sets package jsons

### DIFF
--- a/client/release/scripts/release.sh
+++ b/client/release/scripts/release.sh
@@ -88,8 +88,8 @@ fi
   if [ "$core_modified" = true ]; then
     # Wait for npm to be update to the latest version
     wait_for_npm_publish @1password/sdk-core "${version_sdk_core}"
-    # Update @1password/sdk-core dependancy to the latest
-    npm install @1password/sdk-core@latest -E
+    # Set the package version regardless if npm published or not
+    npm pkg set dependencies.@1password/sdk-core="${version_sdk_core}"
   fi
 
   # Update sdk version number to the latest
@@ -109,8 +109,8 @@ fi
             
             # Wait for npm to be update to the latest version
             wait_for_npm_publish @1password/sdk "${version_sdk}"
-            # Update dependency in examples to run off the latest SDK
-            cd ../examples && npm install @1password/sdk@latest -E
+            # Set the package version regardless if npm published or not
+            cd ../examples && npm pkg set dependencies.@1password/sdk="${version_sdk}"
 
             # Check if the latest SDK client is pulled correctly
             cd ../ && npm install


### PR DESCRIPTION
This PR will update the `release.sh` script to update the `package.json` in the `examples` folder as well as the `client` folder.

The command `npm pkg set` is not coupled with npm's registry so we can use this command to set it to any value we want without relying if it has been updated on NPM. 

I still kept the `wait_for_npm_publish` function to ensure that we still wait for npm to publish before we set it to its correct value as a safety.

## To Test
You can comment out the script but the increment parts and you can update the `version.ts` to any version and try running the `npm run release-stable` script. The `package.json` should be updated with whatever version you updated to.