### PR TITLE
Fix Example Code to Read File Field Correctly

### DIFF
--- a/examples/index.mjs
+++ b/examples/index.mjs
@@ -359,7 +359,7 @@ async function createAndAttachAndDeleteFileFieldItem(client) {
   let content = await client.items.files.read(
     item.vaultId,
     item.id,
-    item.files[0],
+    item.files[0].attributes,
   );
   // [developer-docs.sdk.js.read-file-field]-end
 


### PR DESCRIPTION
This PR will fix the .mjs example to read file fields correctly by passing in correct arguments.