### PR TITLE
Add dependabot for NPM updates for JS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
This PR will add dependabot for the JS SDK ensuring our npm dependencies are up to date! This PR follows the exact same format as Go and Python just changing the `package-ecosystem` to `npm`