### PR TITLE
Improve paths to SDK IPC lib

### DIFF
--- a/client/src/shared_lib_core.ts
+++ b/client/src/shared_lib_core.ts
@@ -38,7 +38,7 @@ const find1PasswordLibPath = (): string => {
     case "linux": // Linux
       searchPaths = [
         "/usr/bin/1password/libop_sdk_ipc_client.so",
-        "/opt/1password/libop_sdk_ipc_client.so",
+        "/opt/1Password/libop_sdk_ipc_client.so",
         "/snap/bin/1password/libop_sdk_ipc_client.so",
       ];
       break;

--- a/client/src/shared_lib_core.ts
+++ b/client/src/shared_lib_core.ts
@@ -24,17 +24,6 @@ const find1PasswordLibPath = (): string => {
       ];
       break;
 
-    case "win32": // Windows
-      searchPaths = [
-        "C:/Program Files/1Password/op_sdk_ipc_client.dll",
-        "C:/Program Files (x86)/1Password/op_sdk_ipc_client.dll",
-        path.join(
-          os.homedir(),
-          "/AppData/Local/1Password/op_sdk_ipc_client.dll",
-        ),
-      ];
-      break;
-
     case "linux": // Linux
       searchPaths = [
         "/usr/bin/1password/libop_sdk_ipc_client.so",


### PR DESCRIPTION
This PR does two changes:
- Make the paths to the SDK IPC client on Linux and MacOS more accurate
- Remove support for Windows. This will not be out yet during beta.