### PR TITLE
Add vault permission operations for groups

### DIFF
--- a/client/src/secrets.ts
+++ b/client/src/secrets.ts
@@ -10,7 +10,7 @@ import {
 
 /**
  * The Secrets API includes all operations the SDK client can perform on secrets.
- * Use secret reference URIs to securely load secrets from 1Password: op://<vault-name>/<item-name>[/<section-name>]/<field-name>
+ * Use secret reference URIs to securely load secrets from 1Password: `op://<vault-name>/<item-name>[/<section-name>]/<field-name>`
  */
 export interface SecretsApi {
   /**

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -129,8 +129,29 @@ export interface Group {
   vaultAccess?: VaultAccess[];
 }
 
+/**
+ * Represents a group's access to a 1Password vault.
+ * This is used for granting permissions
+ */
+export interface GroupAccess {
+  /** The group's ID */
+  group_id: string;
+  /** The group's set of permissions for the vault */
+  permissions: number;
+}
+
 export interface GroupGetParams {
   vaultPermissions?: boolean;
+}
+
+/** Represents a group's access to a 1Password vault. */
+export interface GroupVaultAccess {
+  /** The vault's ID */
+  vault_id: string;
+  /** The group's ID */
+  group_id: string;
+  /** The group's set of permissions for the vault */
+  permissions: number;
 }
 
 export enum ItemCategory {
@@ -215,7 +236,7 @@ export interface ItemSection {
  * Controls the auto-fill behavior of a website.
  *
  *
- * For more information, visit https://support.1password.com/autofill-behavior/
+ * For more information, visit <https://support.1password.com/autofill-behavior/>
  */
 export enum AutofillBehavior {
   /** Auto-fill any page that’s part of the website, including subdomains */
@@ -234,7 +255,7 @@ export interface Website {
   /**
    * The auto-fill behavior of the website
    *
-   * For more information, visit https://support.1password.com/autofill-behavior/
+   * For more information, visit <https://support.1password.com/autofill-behavior/>
    */
   autofillBehavior: AutofillBehavior;
 }
@@ -685,6 +706,20 @@ export enum WordListType {
   ThreeLetters = "threeLetters",
 }
 
+export const ARCHIVE_ITEMS: number = 256;
+export const CREATE_ITEMS: number = 128;
+export const DELETE_ITEMS: number = 512;
+export const EXPORT_ITEMS: number = 4194304;
+export const IMPORT_ITEMS: number = 2097152;
+export const MANAGE_VAULT: number = 2;
+export const NO_ACCESS: number = 0;
+export const PRINT_ITEMS: number = 8388608;
+export const READ_ITEMS: number = 32;
+export const RECOVER_VAULT: number = 1;
+export const REVEAL_ITEM_PASSWORD: number = 16;
+export const SEND_ITEMS: number = 1048576;
+export const UPDATE_ITEMS: number = 64;
+export const UPDATE_ITEM_HISTORY: number = 1024;
 /**
  * Custom JSON reviver and replacer functions for dynamic data transformation
  * ReviverFunc is used during JSON parsing to detect and transform specific data structures

--- a/client/src/vaults.ts
+++ b/client/src/vaults.ts
@@ -2,6 +2,8 @@
 
 import { InvokeConfig, InnerClient, SharedCore } from "./core.js";
 import {
+  GroupAccess,
+  GroupVaultAccess,
   Vault,
   VaultGetParams,
   VaultListParams,
@@ -21,6 +23,12 @@ export interface VaultsApi {
   getOverview(vaultUuid: string): Promise<VaultOverview>;
 
   get(vaultUuid: string, vaultParams: VaultGetParams): Promise<Vault>;
+
+  grantGroupPermissions(vaultId: string, groupPermissionsList: GroupAccess[]);
+
+  updateGroupPermissions(groupPermissionsList: GroupVaultAccess[]);
+
+  revokeGroupPermissions(vaultId: string, groupId: string);
 }
 
 export class Vaults implements VaultsApi {
@@ -89,5 +97,57 @@ export class Vaults implements VaultsApi {
       await this.#inner.core.invoke(invocationConfig),
       ReviverFunc,
     ) as Vault;
+  }
+
+  public async grantGroupPermissions(
+    vaultId: string,
+    groupPermissionsList: GroupAccess[],
+  ) {
+    const invocationConfig: InvokeConfig = {
+      invocation: {
+        clientId: this.#inner.id,
+        parameters: {
+          name: "VaultsGrantGroupPermissions",
+          parameters: {
+            vault_id: vaultId,
+            group_permissions_list: groupPermissionsList,
+          },
+        },
+      },
+    };
+    await this.#inner.core.invoke(invocationConfig);
+  }
+
+  public async updateGroupPermissions(
+    groupPermissionsList: GroupVaultAccess[],
+  ) {
+    const invocationConfig: InvokeConfig = {
+      invocation: {
+        clientId: this.#inner.id,
+        parameters: {
+          name: "VaultsUpdateGroupPermissions",
+          parameters: {
+            group_permissions_list: groupPermissionsList,
+          },
+        },
+      },
+    };
+    await this.#inner.core.invoke(invocationConfig);
+  }
+
+  public async revokeGroupPermissions(vaultId: string, groupId: string) {
+    const invocationConfig: InvokeConfig = {
+      invocation: {
+        clientId: this.#inner.id,
+        parameters: {
+          name: "VaultsRevokeGroupPermissions",
+          parameters: {
+            vault_id: vaultId,
+            group_id: groupId,
+          },
+        },
+      },
+    };
+    await this.#inner.core.invoke(invocationConfig);
   }
 }

--- a/wasm/nodejs/core.js
+++ b/wasm/nodejs/core.js
@@ -37,6 +37,11 @@ function handleError(f, args) {
     }
 }
 
+function getArrayU8FromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return getUint8ArrayMemory0().subarray(ptr / 1, ptr / 1 + len);
+}
+
 function isLikeNone(x) {
     return x === undefined || x === null;
 }
@@ -270,15 +275,15 @@ module.exports.release_client = function(client_id) {
 };
 
 function __wbg_adapter_30(arg0, arg1) {
-    wasm._dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h91cc58ee8643efbd(arg0, arg1);
+    wasm._dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h3aa0e8fb678a82f4(arg0, arg1);
 }
 
 function __wbg_adapter_33(arg0, arg1, arg2) {
-    wasm.closure2333_externref_shim(arg0, arg1, arg2);
+    wasm.closure2323_externref_shim(arg0, arg1, arg2);
 }
 
-function __wbg_adapter_156(arg0, arg1, arg2, arg3) {
-    wasm.closure2482_externref_shim(arg0, arg1, arg2, arg3);
+function __wbg_adapter_160(arg0, arg1, arg2, arg3) {
+    wasm.closure2472_externref_shim(arg0, arg1, arg2, arg3);
 }
 
 const __wbindgen_enum_RequestCache = ["default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached"];
@@ -349,6 +354,11 @@ module.exports.__wbg_getFullYear_17d3c9e4db748eb7 = function(arg0) {
     return ret;
 };
 
+module.exports.__wbg_getRandomValues_5754b82ca6952f9b = function() { return handleError(function (arg0, arg1, arg2) {
+    const ret = arg0.getRandomValues(getArrayU8FromWasm0(arg1, arg2));
+    return ret;
+}, arguments) };
+
 module.exports.__wbg_getRandomValues_b8f5dbd5f3995a9e = function() { return handleError(function (arg0, arg1) {
     arg0.getRandomValues(arg1);
 }, arguments) };
@@ -370,6 +380,17 @@ module.exports.__wbg_has_a5ea9117f258a0ec = function() { return handleError(func
 
 module.exports.__wbg_headers_9cb51cfd2ac780a4 = function(arg0) {
     const ret = arg0.headers;
+    return ret;
+};
+
+module.exports.__wbg_instanceof_Crypto_437466a97e9010b9 = function(arg0) {
+    let result;
+    try {
+        result = arg0 instanceof Crypto;
+    } catch (_) {
+        result = false;
+    }
+    const ret = result;
     return ret;
 };
 
@@ -458,7 +479,7 @@ module.exports.__wbg_new_23a2665fac83c611 = function(arg0, arg1) {
             const a = state0.a;
             state0.a = 0;
             try {
-                return __wbg_adapter_156(a, state0.b, arg0, arg1);
+                return __wbg_adapter_160(a, state0.b, arg0, arg1);
             } finally {
                 state0.a = a;
             }
@@ -708,13 +729,13 @@ module.exports.__wbindgen_cb_drop = function(arg0) {
     return ret;
 };
 
-module.exports.__wbindgen_closure_wrapper8484 = function(arg0, arg1, arg2) {
-    const ret = makeMutClosure(arg0, arg1, 2316, __wbg_adapter_30);
+module.exports.__wbindgen_closure_wrapper8680 = function(arg0, arg1, arg2) {
+    const ret = makeMutClosure(arg0, arg1, 2306, __wbg_adapter_30);
     return ret;
 };
 
-module.exports.__wbindgen_closure_wrapper8524 = function(arg0, arg1, arg2) {
-    const ret = makeMutClosure(arg0, arg1, 2334, __wbg_adapter_33);
+module.exports.__wbindgen_closure_wrapper8711 = function(arg0, arg1, arg2) {
+    const ret = makeMutClosure(arg0, arg1, 2324, __wbg_adapter_33);
     return ret;
 };
 

--- a/wasm/nodejs/core_bg.wasm.d.ts
+++ b/wasm/nodejs/core_bg.wasm.d.ts
@@ -14,7 +14,7 @@ export const __wbindgen_realloc: (a: number, b: number, c: number, d: number) =>
 export const __wbindgen_export_5: WebAssembly.Table;
 export const __externref_table_dealloc: (a: number) => void;
 export const __wbindgen_free: (a: number, b: number, c: number) => void;
-export const _dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h91cc58ee8643efbd: (a: number, b: number) => void;
-export const closure2333_externref_shim: (a: number, b: number, c: any) => void;
-export const closure2482_externref_shim: (a: number, b: number, c: any, d: any) => void;
+export const _dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h3aa0e8fb678a82f4: (a: number, b: number) => void;
+export const closure2323_externref_shim: (a: number, b: number, c: any) => void;
+export const closure2472_externref_shim: (a: number, b: number, c: any, d: any) => void;
 export const __wbindgen_start: () => void;


### PR DESCRIPTION
This PR adds vault permission operations for groups:
- `grantGroupPermissions`
- `updateGroupPermissions`
- `revokeGroupPermissions`

This is done by reverting the code changes from https://github.com/1Password/onepassword-sdk-js/pull/158 with updated WASM related files.