### PR TITLE
Support loading a custom shared library path.

### DIFF
--- a/client/src/client_builder.ts
+++ b/client/src/client_builder.ts
@@ -20,7 +20,7 @@ export const createClientWithCore = async (
   const authConfig = clientAuthConfig(config);
   if (authConfig.accountName) {
     core.setInner(
-      new SharedLibCore(authConfig.accountName, config.customSharedLibraryPath),
+      new SharedLibCore(authConfig.accountName, config.sharedLibraryPath),
     );
   }
   const clientId = await core.initClient(authConfig);

--- a/client/src/client_builder.ts
+++ b/client/src/client_builder.ts
@@ -19,7 +19,9 @@ export const createClientWithCore = async (
 ): Promise<Client> => {
   const authConfig = clientAuthConfig(config);
   if (authConfig.accountName) {
-    core.setInner(new SharedLibCore(authConfig.accountName));
+    core.setInner(
+      new SharedLibCore(authConfig.accountName, config.customSharedLibraryPath),
+    );
   }
   const clientId = await core.initClient(authConfig);
   const inner = new InnerClient(parseInt(clientId, 10), core, authConfig);

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -11,7 +11,7 @@ export interface ClientConfiguration {
   auth: Auth;
   integrationName: string;
   integrationVersion: string;
-  customSharedLibraryPath?: string;
+  sharedLibraryPath?: string;
 }
 
 // Sets the authentication method. Use a token as a `string` to authenticate with a service account token.

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -11,6 +11,7 @@ export interface ClientConfiguration {
   auth: Auth;
   integrationName: string;
   integrationVersion: string;
+  customSharedLibraryPath?: string;
 }
 
 // Sets the authentication method. Use a token as a `string` to authenticate with a service account token.

--- a/client/src/shared_lib_core.ts
+++ b/client/src/shared_lib_core.ts
@@ -8,7 +8,7 @@ import { throwError } from "./errors";
 /**
  * Find the 1Password shared lib path by asking an the wasm core synchronously.
  */
-const find1PasswordLibPath = (): string => {
+const find1PasswordLibPath = (customLocation?: string): string => {
   const platform: NodeJS.Platform = os.platform();
   const appRoot: string = path.dirname(process.execPath);
   let searchPaths: string[] = [];
@@ -47,10 +47,12 @@ const find1PasswordLibPath = (): string => {
         ),
       ];
       break;
-
     default:
       throw new Error(`Unsupported platform: ${platform}`);
   }
+
+  if (typeof customLocation == "string" && customLocation.length > 0)
+    searchPaths.unshift(customLocation);
 
   // Iterate through the possible paths and return the first one that exists.
   for (const addonPath of searchPaths) {
@@ -85,9 +87,9 @@ export class SharedLibCore implements Core {
   private lib: DesktopIPCClient | null = null;
   private acccountName: string;
 
-  public constructor(accountName: string) {
+  public constructor(accountName: string, libraryPath?: string) {
     try {
-      const libPath = find1PasswordLibPath();
+      const libPath = find1PasswordLibPath(libraryPath);
       const moduleStub = { exports: {} };
       process.dlopen(moduleStub, libPath);
 

--- a/client/src/shared_lib_core.ts
+++ b/client/src/shared_lib_core.ts
@@ -51,8 +51,9 @@ const find1PasswordLibPath = (customLocation?: string): string => {
       throw new Error(`Unsupported platform: ${platform}`);
   }
 
-  if (typeof customLocation == "string" && customLocation.length > 0)
+  if (typeof customLocation === "string" && customLocation.length > 0) {
     searchPaths.unshift(customLocation);
+  }
 
   // Iterate through the possible paths and return the first one that exists.
   for (const addonPath of searchPaths) {


### PR DESCRIPTION
Adds a `sharedLibraryPath` option to support loading a custom shared library file location.

This is useful for sandboxed contexts (such as nix) which don't have access to the /opt/1Password (or other) directory and must copy the library into the sandbox.

Related SDK PRs:
- https://github.com/1Password/onepassword-sdk-go/pull/231
- https://github.com/1Password/onepassword-sdk-python/pull/198