### PR TITLE
Release JS SDK v0.4.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1password/sdk",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0",
   "description": "The 1Password JavaScript SDK offers programmatic read access to your secrets in 1Password in an interface native to JavaScript. The SDK currently supports `Node.JS`",
   "scripts": {
     "build": "tsc",
@@ -26,7 +26,7 @@
   "main": "./dist/sdk.js",
   "types": "./dist/sdk.d.ts",
   "dependencies": {
-    "@1password/sdk-core": "0.4.0-beta.2"
+    "@1password/sdk-core": "0.4.0"
   },
   "devDependencies": {
     "@1password/eslint-config": "^4.0.0",

--- a/client/release/RELEASE-NOTES
+++ b/client/release/RELEASE-NOTES
@@ -5,7 +5,7 @@
 - **Desktop App integration:** The SDK can now authenticate via an authorization prompt from the 1Password app. 
 - **Vault CRUDL:** You can now fully manage 1Password vaults with the SDK, including creating, reading, updating, deleting and listing.
 - **Vault group permission management operations:** You can now grant, update and revoke group access to vaults using `grantGroupPermissions`, `updateGroupPermissions`, and `revokeGroupPermissions` functions.
-- **
+- **Item batch management:** You can now retrieve, create, update and delete items in batch, enabling more scalable item management.
 
 
 

--- a/client/release/RELEASE-NOTES
+++ b/client/release/RELEASE-NOTES
@@ -1,12 +1,13 @@
-# 1Password JavaScript SDK v0.4.0-beta.2
+# 1Password JavaScript SDK v0.4.0
 
 ## NEW
 
+- **Desktop App integration:** The SDK can now authenticate via an authorization prompt from the 1Password app. 
+- **Vault CRUDL:** You can now fully manage 1Password vaults with the SDK, including creating, reading, updating, deleting and listing.
 - **Vault group permission management operations:** You can now grant, update and revoke group access to vaults using `grantGroupPermissions`, `updateGroupPermissions`, and `revokeGroupPermissions` functions.
-- **Desktop App integration on Windows:** The SDK can now authenticate via an authorization prompt from the 1Password app on Windows as well. Now all major desktop OSs support this feature.
+- **
 
-## FIXED
 
-- **Vault listing with additional parameters:** `vaults.list` no longer errors when additional parameters are provided.
-- **Handling locked 1Password app state:** When the 1Password app gets locked after the SDK client is authenticated, it will now automatically re-authenticate.
+
+
 

--- a/client/src/version.ts
+++ b/client/src/version.ts
@@ -1,4 +1,4 @@
-export const SDK_VERSION = "0.4.0-beta.2";
-export const SDK_BUILD_NUMBER = "0040002";
-const SDK_CORE_VERSION = "0.4.0-beta.2";
+export const SDK_VERSION = "0.4.1";
+export const SDK_BUILD_NUMBER = "0040003";
+const SDK_CORE_VERSION = "0.4.1";
 

--- a/client/src/version.ts
+++ b/client/src/version.ts
@@ -1,4 +1,4 @@
-export const SDK_VERSION = "0.4.1";
+export const SDK_VERSION = "0.4.0";
 export const SDK_BUILD_NUMBER = "0040003";
-const SDK_CORE_VERSION = "0.4.1";
+const SDK_CORE_VERSION = "0.4.0";
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
     "prettier-fix": "prettier --write index.*js"
   },
   "dependencies": {
-    "@1password/sdk": "0.4.0-beta.2"
+    "@1password/sdk": "0.4.0"
   },
   "devDependencies": {
     "prettier": "3.1.1"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1password/sdk-core",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0",
   "author": "1Password",
   "license": "MIT",
   "description": "The 1Password Rust SDK core built with `wasm_bindgen`",


### PR DESCRIPTION
## Summary

Release candidate for 0.4.0. Created with `npm run prep-release`.