### PR TITLE
Update README to reflect latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ You can choose between two [authentication methods](https://developer.1password.
 [1Password desktop app authentication](https://developer.1password.com/docs/sdks/concepts#1password-desktop-app) is best for local integrations that require minimal setup from end users and sensitive workflows that require human-in-the-loop approval. 
 
 1. Install the [1Password desktop app](https://1password.com/downloads/) and sign in to your account in the app.
-2. Select your account or collection at the top of the sidebar, then navigate to **Settings** > **[Developer](onepassword://settings/developers)**.
+2. Select your account or collection at the top of the sidebar, then navigate to **Settings** > **Developer**.
 3. Under Integrate with the 1Password SDKs, select **Integrate with other apps**.
-4. If you want to authenticate with biometrics, navigate to **Settings** > **[Security](onepassword://settings/security)**, then turn on the option to unlock using [Touch ID](https://support.1password.com/touch-id-mac/),  [Windows Hello](https://support.1password.com/windows-hello/), or [system authentication](https://support.1password.com/system-authentication-linux/).
+4. If you want to authenticate with biometrics, navigate to **Settings** > **Security**, then turn on the option to unlock using [Touch ID](https://support.1password.com/touch-id-mac/),  [Windows Hello](https://support.1password.com/windows-hello/), or [system authentication](https://support.1password.com/system-authentication-linux/).
 5. Install the 1Password JavaScript SDK in your project:
 
    ```bash
@@ -65,7 +65,7 @@ Make sure to use [secret reference URIs](https://developer.1password.com/docs/cl
 
 ### Option 2: 1Password Service Account
 
-[Service account authentication](https://developer.1password.com/docs/sdks/concepts#service-account) is best for automated access and limiting your integration to least privilege access.
+[Service account authentication](https://developer.1password.com/docs/sdks/concepts/#1password-service-account) is best for automated access and limiting your integration to least privilege access.
 
 1. [Create a service account](https://my.1password.com/developer-tools/infrastructure-secrets/serviceaccount/?source=github-sdk) and give it the appropriate permissions in the vaults where the items you want to use with the SDK are saved.
 2. Provision your service account token. We recommend provisioning your token from the environment. For example, to export your token to the `OP_SERVICE_ACCOUNT_TOKEN` environment variable:
@@ -196,7 +196,6 @@ Inside `createClient()`, set `integrationName` to the name of your application a
 ## 📖 Learn more
 
 - [Load secrets](https://developer.1password.com/docs/sdks/load-secrets)
-- [Read 1Password Environments (beta)](https://developer.1password.com/docs/sdks/environments)
 - [Manage items](https://developer.1password.com/docs/sdks/manage-items)
 - [Manage files](https://developer.1password.com/docs/sdks/files)
 - [Share items](https://developer.1password.com/docs/sdks/share-items)

--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ Inside `createClient()`, set `integrationName` to the name of your application a
 - [ ] Update group membership
 
 ### Compliance & reporting
+
 - [ ] Watchtower insights
 - [ ] Travel mode
-- [ ] Events ([#76](https://github.com/1Password/onepassword-sdk-go/issues/76)). For now, use [1Password Events Reporting API](https://developer.1password.com/docs/events-api/) directly.
+- [ ] Events. For now, use [1Password Events Reporting API](https://developer.1password.com/docs/events-api/) directly.
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
- <h4 align="center">Build integrations that programmatically access your secrets in 1Password.</h4>
+ <h4 align="center">Build integrations that programmatically interact with 1Password.</h4>
 </p>
 
 <p align="center">
@@ -16,7 +16,56 @@
 
 ## 🚀 Get started
 
-To use the 1Password JavaScript SDK in your project:
+You can choose between two [authentication methods](https://developer.1password.com/docs/sdks/concepts#authentication) for the 1Password JavaScript SDK: local authorization prompts from the [1Password desktop app](#option-1-1password-desktop-app) or automated authentication with a [1Password Service Account](#option-2-1password-service-account).
+
+### Option 1: 1Password desktop app
+
+[1Password desktop app authentication](https://developer.1password.com/docs/sdks/concepts#1password-desktop-app) is best for local integrations that require minimal setup and sensitive workflows that require human-in-the-loop approval. 
+
+1. Install the [1Password desktop app](https://1password.com/downloads/) and sign in to your account in the app.
+2. Select your account or collection at the top of the sidebar, then navigate to **Settings** > **[Developer](onepassword://settings/developers)**.
+3. Under Integrate with the 1Password SDKs, select **Integrate with other apps**.
+4. If you want to authenticate with biometrics, navigate to **Settings** > **[Security](onepassword://settings/security)**, then turn on the option to unlock using [Touch ID](https://support.1password.com/touch-id-mac/),  [Windows Hello](https://support.1password.com/windows-hello/), or [system authentication](https://support.1password.com/system-authentication-linux/).
+5. Install the 1Password JavaScript SDK in your project:
+
+   ```bash
+   ## NPM
+   npm install @1password/sdk
+   ```
+
+   ```bash
+   ## PNPM
+   pnpm add @1password/sdk
+   ```
+
+   ```bash
+   ## Yarn
+   yarn add @1password/sdk
+
+6. To use the Javascript SDK in your project, replace `your-account-name` in the code below with the name of your 1Password account as it appears at the top left sidebar of the 1Password desktop app.
+
+```js
+import { createClient } from "@1password/sdk";
+
+// Creates an authenticated client.
+const client = await createClient({
+  auth: new sdk.DesktopAuth("your-account-name"),
+  // Set the following to your own integration name and version.
+  integrationName: "My 1Password Integration",
+  integrationVersion: "v1.0.0",
+});
+
+// Fetches a secret.
+const secret = await client.secrets.resolve("op://vault/item/field");
+```
+
+Inside `createClient()`, set `integrationName` to the name of your application and `integrationVersion` to the version of your application.
+
+Make sure to use [secret reference URIs](https://developer.1password.com/docs/cli/secret-reference-syntax/) with the syntax `op://vault/item/field` to securely load secrets from 1Password into your code.
+
+### Option 2: 1Password Service Account
+
+[Service account authentication](https://developer.1password.com/docs/sdks/concepts#service-account) is best for automated access and limiting your integration to least privilege access.
 
 1. [Create a service account](https://my.1password.com/developer-tools/infrastructure-secrets/serviceaccount/?source=github-sdk) and give it the appropriate permissions in the vaults where the items you want to use with the SDK are saved.
 2. Provision your service account token. We recommend provisioning your token from the environment. For example, to export your token to the `OP_SERVICE_ACCOUNT_TOKEN` environment variable:
@@ -77,7 +126,7 @@ Inside `createClient()`, set `integrationName` to the name of your application a
 
 ### Item management
 
-Operations:
+**Operations:**
 
 - [x] [Retrieve secrets](https://developer.1password.com/docs/sdks/load-secrets)
 - [x] [Retrieve items](https://developer.1password.com/docs/sdks/manage-items#get-an-item)
@@ -89,7 +138,8 @@ Operations:
 - [x] [Share items](https://developer.1password.com/docs/sdks/share-items)
 - [x] [Generate PIN, random and memorable passwords](https://developer.1password.com/docs/sdks/manage-items#generate-a-password)
 
-Field types:
+**Field types:**
+
 - [x] API Keys
 - [x] Passwords
 - [x] Concealed fields
@@ -112,35 +162,51 @@ Field types:
 - [ ] Passkeys
 
 ### Vault management
-- [ ] Retrieve vaults
-- [ ] Create vaults ([#50](https://github.com/1Password/onepassword-sdk-js/issues/50))
-- [ ] Update vaults
-- [ ] Delete vaults
-- [x] [List vaults](https://developer.1password.com/docs/sdks/list-vaults-items/)
+
+- [x] [Retrieve vaults](https://developer.1password.com/docs/sdks/vaults#get-a-vault-overview)
+- [x] [Create vaults](https://developer.1password.com/docs/sdks/vaults#create-a-vault)
+- [x] [Update vaults](https://developer.1password.com/docs/sdks/vaults#update-a-vault)
+- [x] [Delete vaults](https://developer.1password.com/docs/sdks/vaults#delete-a-vault)
+- [x] [List vaults](https://developer.1password.com/docs/sdks/list-vaults-items#list-vaults)
+- [x] [Manage group vault permissions](https://developer.1password.com/docs/sdks/vault-permissions)
+- [ ] Manage user vault permissions
 
 ### User & access management
+
 - [ ] Provision users
 - [ ] Retrieve users
 - [ ] List users
 - [ ] Suspend users
+- [x] [Retrieve groups](https://developer.1password.com/docs/sdks/groups/)
+- [ ] List groups
 - [ ] Create groups
 - [ ] Update group membership
-- [ ] Update vault access & permissions
+
+
+## Environments management
+
+- [x] [Read 1Password Environments](/docs/sdks/environments) (beta)
 
 ### Compliance & reporting
 - [ ] Watchtower insights
 - [ ] Travel mode
-- [ ] Events. For now, use [1Password Events Reporting API](https://developer.1password.com/docs/events-api/) directly.
+- [ ] Events ([#76](https://github.com/1Password/onepassword-sdk-go/issues/76)). For now, use [1Password Events Reporting API](https://developer.1password.com/docs/events-api/) directly.
 
 ### Authentication
 
-- [x] [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/)
-- [ ] User authentication
-- [ ] 1Password Connect. For now, use [1Password/connect-sdk-js](https://github.com/1Password/connect-sdk-js).
+- [x] [1Password Service Accounts](https://developer.1password.com/docs/sdks/concepts#1password-service-account)
+- [x] [User authentication](https://developer.1password.com/docs/sdks/concepts#1password-desktop-app)
+- [ ] 1Password Connect. For now, use [1Password/connect-sdk-go](https://github.com/1Password/connect-sdk-go).
 
 ## 📖 Learn more
 
-- [Load secrets with 1Password SDKs](https://developer.1password.com/docs/sdks/load-secrets)
-- [Manage items with 1Password SDKs](https://developer.1password.com/docs/sdks/manage-items)
-- [List vaults and items with 1Password SDKs](https://developer.1password.com/docs/sdks/list-vaults-items)
+- [Load secrets](https://developer.1password.com/docs/sdks/load-secrets)
+- [Read 1Password Environments (beta)](https://developer.1password.com/docs/sdks/environments)
+- [Manage items](https://developer.1password.com/docs/sdks/manage-items)
+- [Manage files](https://developer.1password.com/docs/sdks/files)
+- [Share items](https://developer.1password.com/docs/sdks/share-items)
+- [List vaults and items](https://developer.1password.com/docs/sdks/list-vaults-items)
+- [Manage vaults](https://developer.1password.com/docs/sdks/vaults)
+- [Manage vault permissions](https://developer.1password.com/docs/sdks/vault-permissions)
 - [1Password SDK concepts](https://developer.1password.com/docs/sdks/concepts)
+- [Manage groups](https://developer.1password.com/docs/sdks/groups)

--- a/README.md
+++ b/README.md
@@ -182,10 +182,6 @@ Inside `createClient()`, set `integrationName` to the name of your application a
 - [ ] Create groups
 - [ ] Update group membership
 
-## Environments management
-
-- [x] [Read 1Password Environments](/docs/sdks/environments) (beta)
-
 ### Compliance & reporting
 - [ ] Watchtower insights
 - [ ] Travel mode

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Inside `createClient()`, set `integrationName` to the name of your application a
 **Operations:**
 
 - [x] [Retrieve secrets](https://developer.1password.com/docs/sdks/load-secrets)
+- [Read 1Password Environments (beta)](https://developer.1password.com/docs/sdks/environments)
 - [x] [Retrieve items](https://developer.1password.com/docs/sdks/manage-items#get-an-item)
 - [x] [Create items](https://developer.1password.com/docs/sdks/manage-items#create-an-item)
 - [x] [Update items](https://developer.1password.com/docs/sdks/manage-items#update-an-item)
@@ -181,6 +182,10 @@ Inside `createClient()`, set `integrationName` to the name of your application a
 - [ ] List groups
 - [ ] Create groups
 - [ ] Update group membership
+
+## Environments management
+
+- [x] [Read 1Password Environments](/docs/sdks/environments) (beta)
 
 ### Compliance & reporting
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Inside `createClient()`, set `integrationName` to the name of your application a
 
 - [x] [1Password Service Accounts](https://developer.1password.com/docs/sdks/concepts#1password-service-account)
 - [x] [User authentication](https://developer.1password.com/docs/sdks/concepts#1password-desktop-app)
-- [ ] 1Password Connect. For now, use [1Password/connect-sdk-go](https://github.com/1Password/connect-sdk-go).
+- [ ] 1Password Connect. For now, use [1Password/connect-sdk-go](https://github.com/1Password/connect-sdk-js).
 
 ## 📖 Learn more
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can choose between two [authentication methods](https://developer.1password.
 
 ### Option 1: 1Password desktop app
 
-[1Password desktop app authentication](https://developer.1password.com/docs/sdks/concepts#1password-desktop-app) is best for local integrations that require minimal setup and sensitive workflows that require human-in-the-loop approval. 
+[1Password desktop app authentication](https://developer.1password.com/docs/sdks/concepts#1password-desktop-app) is best for local integrations that require minimal setup from end users and sensitive workflows that require human-in-the-loop approval. 
 
 1. Install the [1Password desktop app](https://1password.com/downloads/) and sign in to your account in the app.
 2. Select your account or collection at the top of the sidebar, then navigate to **Settings** > **[Developer](onepassword://settings/developers)**.
@@ -182,7 +182,6 @@ Inside `createClient()`, set `integrationName` to the name of your application a
 - [ ] Create groups
 - [ ] Update group membership
 
-
 ## Environments management
 
 - [x] [Read 1Password Environments](/docs/sdks/environments) (beta)
@@ -208,5 +207,5 @@ Inside `createClient()`, set `integrationName` to the name of your application a
 - [List vaults and items](https://developer.1password.com/docs/sdks/list-vaults-items)
 - [Manage vaults](https://developer.1password.com/docs/sdks/vaults)
 - [Manage vault permissions](https://developer.1password.com/docs/sdks/vault-permissions)
-- [1Password SDK concepts](https://developer.1password.com/docs/sdks/concepts)
 - [Manage groups](https://developer.1password.com/docs/sdks/groups)
+- [1Password SDK concepts](https://developer.1password.com/docs/sdks/concepts)

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Inside `createClient()`, set `integrationName` to the name of your application a
 
 - [x] [1Password Service Accounts](https://developer.1password.com/docs/sdks/concepts#1password-service-account)
 - [x] [User authentication](https://developer.1password.com/docs/sdks/concepts#1password-desktop-app)
-- [ ] 1Password Connect. For now, use [1Password/connect-sdk-go](https://github.com/1Password/connect-sdk-js).
+- [ ] 1Password Connect. For now, use [1Password/connect-sdk-js](https://github.com/1Password/connect-sdk-js).
 
 ## 📖 Learn more
 

--- a/README.md
+++ b/README.md
@@ -45,18 +45,22 @@ You can choose between two [authentication methods](https://developer.1password.
 6. To use the Javascript SDK in your project, replace `your-account-name` in the code below with the name of your 1Password account as it appears at the top left sidebar of the 1Password desktop app.
 
 ```js
-import { createClient } from "@1password/sdk";
+const sdk = require("@1password/sdk");
 
-// Creates an authenticated client.
-const client = await createClient({
-  auth: new sdk.DesktopAuth("your-account-name"),
-  // Set the following to your own integration name and version.
-  integrationName: "My 1Password Integration",
-  integrationVersion: "v1.0.0",
-});
+async function main() {
+  // Creates an authenticated client.
+  const client = await sdk.createClient({
+    auth: new sdk.DesktopAuth("your-account-name"),
+    // Set the following to your own integration name and version.
+    integrationName: "My 1Password Integration",
+    integrationVersion: "v1.0.0",
+  });
 
-// Fetches a secret.
-const secret = await client.secrets.resolve("op://vault/item/field");
+  // Fetches a secret.
+  const secret = await client.secrets.resolve("op://vault/item/field");
+}
+
+main()
 ```
 
 Inside `createClient()`, set `integrationName` to the name of your application and `integrationVersion` to the version of your application.
@@ -102,18 +106,22 @@ Make sure to use [secret reference URIs](https://developer.1password.com/docs/cl
 4. Use the JavaScript SDK in your project:
 
 ```js
-import { createClient } from "@1password/sdk";
+const sdk = require("@1password/sdk");
 
-// Creates an authenticated client.
-const client = await createClient({
-  auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
-  // Set the following to your own integration name and version.
-  integrationName: "My 1Password Integration",
-  integrationVersion: "v1.0.0",
-});
+async function main() {
+  // Creates an authenticated client.
+  const client = await sdk.createClient({
+    auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
+    // Set the following to your own integration name and version.
+    integrationName: "My 1Password Integration",
+    integrationVersion: "v1.0.0",
+  });
 
-// Fetches a secret.
-const secret = await client.secrets.resolve("op://vault/item/field");
+  // Fetches a secret.
+  const secret = await client.secrets.resolve("op://vault/item/field");
+}
+
+main()
 ```
 
 Make sure to use [secret reference URIs](https://developer.1password.com/docs/cli/secret-reference-syntax/) with the syntax `op://vault/item/field` to securely load secrets from 1Password into your code.


### PR DESCRIPTION
This PR updates the README to add instructions for using 1Password desktop app authentication and update the supported functionality list to reflect recent changes.

It makes the following changes:

- Updates summary line to reflect broader usage, aligning with the updates to the developer docs
- Updates the intro to introduce the two authentication methods
- Adds a new section for desktop app authentication, with its own example (please test and check the syntax here)
- Updates supported functionality 
- Updates learn more section