### PR TITLE
Fix release script

### DIFF
--- a/client/release/scripts/release.sh
+++ b/client/release/scripts/release.sh
@@ -19,7 +19,7 @@ cleanup() {
     cd "$(git rev-parse --show-toplevel)"
     # restores all files
     git checkout -- .
-    exit 1   
+    exit 1
 }
 
 # waits for NPM to publish on internal registry to update package json
@@ -63,6 +63,16 @@ if [ -z "${GITHUB_TOKEN}" ]; then
 fi
 
 if [ "$core_modified" = "true" ]; then
+    # Point the client at the new core version BEFORE bumping wasm below.
+    #
+    # Why this order matters: bumping the wasm version makes npm re-link the workspace
+    # and rebuild the client. The client only uses our local core when their versions
+    # match. If the client still asks for the OLD version, npm grabs the old core from
+    # the registry instead and the build fails, because the old core doesn't have the
+    # new functions yet. Setting the client's version first keeps them matched, so the
+    # rebuild uses our local core.
+    npm pkg set dependencies.@1password/sdk-core="${version_sdk_core}" --workspace client
+
     cd wasm
     # Update core version number to the latest
     npm version "${version_sdk_core}"
@@ -104,7 +114,7 @@ fi
   npm version "${version_sdk}"
 
   # Check if the latest core is pulled correctly
-  npm install 
+  npm install
 
   # Check if all files pertaining to sdk are included
   RELEASE_CHANNEL="${RELEASE_CHANNEL}" npm run publish-test

--- a/client/release/scripts/release.sh
+++ b/client/release/scripts/release.sh
@@ -63,14 +63,6 @@ if [ -z "${GITHUB_TOKEN}" ]; then
 fi
 
 if [ "$core_modified" = "true" ]; then
-    # Point the client at the new core version BEFORE bumping wasm below.
-    #
-    # Why this order matters: bumping the wasm version makes npm re-link the workspace
-    # and rebuild the client. The client only uses our local core when their versions
-    # match. If the client still asks for the OLD version, npm grabs the old core from
-    # the registry instead and the build fails, because the old core doesn't have the
-    # new functions yet. Setting the client's version first keeps them matched, so the
-    # rebuild uses our local core.
     npm pkg set dependencies.@1password/sdk-core="${version_sdk_core}" --workspace client
 
     cd wasm
@@ -106,8 +98,6 @@ fi
   if [ "$core_modified" = true ]; then
     # Wait for npm to be update to the latest version
     wait_for_npm_publish @1password/sdk-core "${version_sdk_core}"
-    # Set the package version regardless if npm published or not
-    npm pkg set dependencies.@1password/sdk-core="${version_sdk_core}"
   fi
 
   # Update sdk version number to the latest


### PR DESCRIPTION
Added a step in `release.sh` to point the client at the new core version before bumping the wasm/core version.

## Why
The release script crashed during `npm version` on the core whenever a release introduced a new core export (e.g. `init_client_oidc` for Workload Identity).

- Bumping the core's version makes npm re-link the workspace and rebuild the client.
- The client only uses our **local** core when their versions match. Once the core was bumped, the client still pinned the  old version, so npm pulled the old published core from the registry instead.
- The old core doesn't have the new function yet and the build failed with `has no exported member 'init_client_oidc'`.

```
jill.regan@Mac onepassword-sdk-js % npm run release

> release
> client/release/scripts/release.sh true beta

@1password/sdk-core
v0.5.0-beta.1
npm error code 2
npm error path /Users/jill.regan/onepassword-sdk-js/client
npm error command failed
npm error command sh -c rm -rf ./dist && npm run build
npm error > @1password/sdk@0.4.1-beta.1 build
npm error > tsc
npm error
npm error src/core.ts(3,3): error TS2724: '"@1password/sdk-core"' has no exported member named 'init_client_oidc'. Did you mean 'init_client'?
npm error npm error Lifecycle script `build` failed with error:
npm error npm error code 2
npm error npm error path /Users/jill.regan/onepassword-sdk-js/client
npm error npm error workspace @1password/sdk@0.4.1-beta.1
npm error npm error location /Users/jill.regan/onepassword-sdk-js/client
npm error npm error command failed
npm error npm error command sh -c tsc
npm error A complete log of this run can be found in: /Users/jill.regan/.npm/_logs/2026-06-16T19_45_50_894Z-debug-0.log
Performing cleanup tasks...
```

## How to test
1. On this branch where the core, set `NPM_TOKEN` empty so nothing can publish `unset NPM_TOKEN` as a safety measure
2. Run `npm run release`
3. Confirm it gets past the `cd wasm; npm version` step without the `has no exported member` build error, and reaches the core publish dry-run `Is everything good? (y/n)` prompt.
4. Answer `n` the script cleans up and exits. Nothing is published.

Before the fix, step 3 fails at `npm version` with:
`'@1password/sdk-core' has no exported member named 'init_client_oidc'`
