### PR TITLE
ci: bump GitHub Actions off deprecated Node runtimes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,10 +16,10 @@ jobs:
         node-version: ['18.x', '20.x', '22.x', 'latest']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -44,10 +44,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 


### PR DESCRIPTION
Bumps GitHub Actions in `validate.yml` to their latest majors:

- `actions/checkout` v3 → v7
- `actions/setup-node` v4 → v6

## Why

The Node 16 (checkout@v3) and Node 20 (setup-node@v4) runtimes are deprecated. Both actions now run on the Node 24 runtime.