### PR TITLE
Prepare Release 0.4.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1password/sdk",
-  "version": "0.4.1-beta.1",
+  "version": "0.4.1",
   "description": "The 1Password JavaScript SDK offers programmatic read access to your secrets in 1Password in an interface native to JavaScript. The SDK currently supports `Node.JS`",
   "scripts": {
     "build": "tsc",
@@ -26,7 +26,7 @@
   "main": "./dist/sdk.js",
   "types": "./dist/sdk.d.ts",
   "dependencies": {
-    "@1password/sdk-core": "0.4.1-beta.1"
+    "@1password/sdk-core": "0.4.1"
   },
   "devDependencies": {
     "@1password/eslint-config": "^4.0.0",

--- a/client/release/RELEASE-NOTES
+++ b/client/release/RELEASE-NOTES
@@ -1,4 +1,4 @@
-# 1Password JavaScript SDK v0.4.1-beta.1
+# 1Password JavaScript SDK v0.4.1
 
 ## NEW
 

--- a/client/release/RELEASE-NOTES
+++ b/client/release/RELEASE-NOTES
@@ -4,3 +4,8 @@
 
 
 - **1Password Environment access:** The SDK can now read variables from a 1Password Environment.
+
+## IMPROVED
+
+- **Documentation:** The README now covers desktop app authentication and an updated list of supported functionality. Examples cover vault and group permission operations, and are consistent with the other 1Password SDKs.
+- **Terms of Service:** The README now links the terms of service that apply to the 1Password APIs/SDKs.

--- a/client/src/version.ts
+++ b/client/src/version.ts
@@ -1,4 +1,4 @@
-export const SDK_VERSION = "0.4.1-beta.1";
-export const SDK_BUILD_NUMBER = "0040101";
-const SDK_CORE_VERSION = "0.4.1-beta.1";
+export const SDK_VERSION = "0.4.1";
+export const SDK_BUILD_NUMBER = "0040102";
+const SDK_CORE_VERSION = "0.4.1";
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
     "prettier-fix": "prettier --write index.*js"
   },
   "dependencies": {
-    "@1password/sdk": "0.4.1-beta.1"
+    "@1password/sdk": "0.4.1"
   },
   "devDependencies": {
     "prettier": "3.1.1"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1password/sdk-core",
-  "version": "0.4.1-beta.1",
+  "version": "0.4.1",
   "author": "1Password",
   "license": "MIT",
   "description": "The 1Password Rust SDK core built with `wasm_bindgen`",


### PR DESCRIPTION
 ## What
  
  Release bookkeeping for **v0.4.1**, the first stable release carrying the Environments read API. The feature itself landed in #195 (`beta` → `main`); this PR is just the version bump and release notes.

  `0.4.1-beta.1` → `0.4.1`, build `0040101` → `0040102`.