### PR TITLE
Prepare Release 0.5.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1password/sdk",
-  "version": "0.5.0-beta.1",
+  "version": "0.5.0",
   "description": "The 1Password JavaScript SDK offers programmatic read access to your secrets in 1Password in an interface native to JavaScript. The SDK currently supports `Node.JS`",
   "scripts": {
     "build": "tsc",
@@ -26,7 +26,7 @@
   "main": "./dist/sdk.js",
   "types": "./dist/sdk.d.ts",
   "dependencies": {
-    "@1password/sdk-core": "0.5.0-beta.1"
+    "@1password/sdk-core": "0.5.0"
   },
   "devDependencies": {
     "@1password/eslint-config": "^4.0.0",

--- a/client/release/RELEASE-NOTES
+++ b/client/release/RELEASE-NOTES
@@ -1,7 +1,6 @@
-# 1Password JavaScript SDK v0.5.0-beta.1
+# 1Password JavaScript SDK v0.5.0
 
 ## NEW
 
 
-- **Workload Identity authentication (private beta):** The SDK can now authenticate using workload identity via 1Password Credential Broker. Provide an `oidcFetcher` and `workloadDetails` to `createClient()` instead of a service account token. Currently in private beta and available for GitHub Actions only.
-
+- **Workload Identity authentication (public preview):** The SDK can now authenticate using workload identity via 1Password Credential Broker. Provide an `oidcFetcher` and `workloadDetails` to `createClient()` instead of a service account token. Currently available for GitHub Actions only.

--- a/client/src/version.ts
+++ b/client/src/version.ts
@@ -1,4 +1,4 @@
-export const SDK_VERSION = "0.5.0-beta.1";
-export const SDK_BUILD_NUMBER = "0050001";
-const SDK_CORE_VERSION = "0.5.0-beta.1";
+export const SDK_VERSION = "0.5.0";
+export const SDK_BUILD_NUMBER = "0050002";
+const SDK_CORE_VERSION = "0.5.0";
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
     "prettier-fix": "prettier --write index.*js"
   },
   "dependencies": {
-    "@1password/sdk": "0.5.0-beta.1"
+    "@1password/sdk": "0.5.0"
   },
   "devDependencies": {
     "prettier": "3.1.1"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1password/sdk-core",
-  "version": "0.5.0-beta.1",
+  "version": "0.5.0",
   "author": "1Password",
   "license": "MIT",
   "description": "The 1Password Rust SDK core built with `wasm_bindgen`",


### PR DESCRIPTION
## What

Release bookkeeping for **v0.5.0**, promoting `0.5.0-beta.1` to stable. Workload Identity authentication moves from private beta to public preview. The code itself landed in #198 and #199; this PR is just the version bump and release notes.

`0.5.0-beta.1` → `0.5.0`, build `0050001` → `0050002`, core `0.5.0-beta.1` → `0.5.0`.