### PR TITLE
Update Integration Tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,7 @@ jobs:
   test:
     name: Test
     strategy:
+      max-parallel: 2
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         # actively maintained versions at the time of writing (Oct 4th, 2024)

--- a/client/test/task.js
+++ b/client/test/task.js
@@ -14,7 +14,7 @@ async function retrieveSecret() {
         integrationVersion: DEFAULT_INTEGRATION_VERSION,
     })
 
-    return await client.secrets.resolve("op://gowwbvgow7kxocrfmfvtwni6vi/6ydrn7ne6mwnqc2prsbqx4i4aq/password")
+    return await client.secrets.resolve("op://dm42px5dmgusczoarfdubfmodm/2fwfzpvjvaey2lwph5jupovjaq/password")
 }
 
 module.exports = { retrieveSecret }

--- a/examples/index.mjs
+++ b/examples/index.mjs
@@ -488,13 +488,13 @@ function generateSpecialItemFields() {
   ];
 }
 
-async function resolveAllSecrets(client) {
+async function resolveAllSecrets(client, vaultId, itemId, fieldId, fieldId2) {
   // [developer-docs.sdk.js.resolve-bulk-secret]-start
   try {
     // Fetch multiple secrets using secret references
     const secrets = await client.secrets.resolveAll([
-      "op://7turaasywpymt3jecxoxk5roli/hdvxoumwprditdustkxv7d3dqy/username",
-      "op://7turaasywpymt3jecxoxk5roli/hdvxoumwprditdustkxv7d3dqy/password",
+      `op://${vaultId}/${itemId}/${fieldId}`,
+      `op://${vaultId}/${itemId}/${fieldId2}`,
     ]);
 
     for (const [_, response] of Object.entries(secrets.individualResponses)) {


### PR DESCRIPTION
The old test account is no longer valid, so the integration tests and examples now point at a new vault.

- client/test/task.js: updated the hardcoded secret reference to the new vault and item.
- examples/index.mjs: `resolveAllSecrets` had a hardcoded vault/item baked in and ignored the arguments it was already being called with. 
.github/workflows/validate.yml: added `max-parallel: 2.` The full 12-job matrix hitting one test account at once was causing contention.